### PR TITLE
Using the Craft 4 call to get all custom fields

### DIFF
--- a/src/services/AlgoliaSyncService.php
+++ b/src/services/AlgoliaSyncService.php
@@ -368,7 +368,7 @@ class AlgoliaSyncService extends Component
                 $recordUpdate['attributes']['postDate'] = (int)$element->postDate->getTimestamp();
             }
 
-            $fields = $element->getFieldLayout()->getFields();
+            $fields = $element->getFieldLayout()->customFields;
 
             $arrayFieldTypes = array('entries','tags','users');
 


### PR DESCRIPTION
[Fix] Updating the call for the list of custom fields in Craft 4