### PR TITLE
Parsing Index Name Overrides

### DIFF
--- a/src/services/AlgoliaSyncService.php
+++ b/src/services/AlgoliaSyncService.php
@@ -576,7 +576,7 @@ class AlgoliaSyncService extends Component
             $potentialIndexOverride = $allSettings['algoliaElements'][$eventInfo['type']][$sectionId]['customIndex'];
 
             if (!empty($potentialIndexOverride)) {
-                $returnIndex[] = $potentialIndexOverride;
+                $returnIndex[] = App::parseEnv($potentialIndexOverride);
                 return $returnIndex;
             }
         }


### PR DESCRIPTION
Parsing the override index name(s) such that .env variables are supported