### PR TITLE
Add configurable queue job priority

### DIFF
--- a/src/AlgoliaSync.php
+++ b/src/AlgoliaSync.php
@@ -79,11 +79,27 @@ class AlgoliaSync extends Plugin
     // =========================================================================
 
     /**
-     * To execute your plugin’s migrations, you’ll need to increase its schema version.
+     * To execute your plugin's migrations, you'll need to increase its schema version.
      *
      * @var string
      */
     public string $schemaVersion = '1.0.1';
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Push a job to the queue with the configured priority
+     *
+     * @param \craft\queue\BaseJob $job The job to push
+     * @return string|null The job ID
+     */
+    public function pushToQueue($job): ?string
+    {
+        $settings = $this->getSettings();
+        $priority = $settings->queuePriority ?? 50;
+        return Craft::$app->getQueue()->priority($priority)->push($job);
+    }
 
 
     // Public Methods

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -77,7 +77,6 @@ class DefaultController extends Controller
             return $this->redirectToPostedUrl();
         }
 
-        $queue = Craft::$app->getQueue();
         $queuedCount = 0;
 
         foreach ($loadRecordTypes as $loadRecordType) {
@@ -88,7 +87,7 @@ class DefaultController extends Controller
 
             $messageString = 'Queueing Up Bulk Records to sync into Algolia (Type: ' . $loadRecordArray[0] . ', ID: ' . $loadRecordArray[1] . ')';
 
-            $queue->push(new AlgoliaBulkLoadTask([
+            AlgoliaSync::$plugin->pushToQueue(new AlgoliaBulkLoadTask([
                 'description' => Craft::t('algolia-sync', $messageString),
                 'loadRecordType' => $loadRecordArray,
             ]));

--- a/src/jobs/AlgoliaBulkLoadTask.php
+++ b/src/jobs/AlgoliaBulkLoadTask.php
@@ -119,7 +119,7 @@ class AlgoliaBulkLoadTask extends BaseJob implements RetryableJobInterface
                 ]
             );
 
-            $queue->push(new AlgoliaChunkLoadTask([
+            AlgoliaSync::$plugin->pushToQueue(new AlgoliaChunkLoadTask([
                 'description'    => $desc,
                 'loadRecordType' => $this->loadRecordType,
                 'limit'          => $this->standardLimit,

--- a/src/jobs/AlgoliaCleanupBatchJob.php
+++ b/src/jobs/AlgoliaCleanupBatchJob.php
@@ -272,7 +272,7 @@ class AlgoliaCleanupBatchJob extends BaseJob
      */
     protected function queueDeletion(string $objectID, string $reason): void
     {
-        Craft::$app->getQueue()->push(new AlgoliaSyncTask([
+        AlgoliaSync::$plugin->pushToQueue(new AlgoliaSyncTask([
             'algoliaIndex' => [$this->indexName],
             'algoliaFunction' => 'delete',
             'algoliaObjectID' => $objectID,

--- a/src/jobs/AlgoliaCleanupCoordinatorJob.php
+++ b/src/jobs/AlgoliaCleanupCoordinatorJob.php
@@ -33,7 +33,7 @@ class AlgoliaCleanupCoordinatorJob extends BaseJob
 
         // Queue one job per index
         foreach ($elementsToCheck as $elementConfig) {
-            Craft::$app->getQueue()->push(new AlgoliaCleanupIndexJob([
+            AlgoliaSync::$plugin->pushToQueue(new AlgoliaCleanupIndexJob([
                 'indexName' => $elementConfig['index'],
                 'elementType' => $elementConfig['type'],
                 'sectionId' => $elementConfig['sectionId'],

--- a/src/jobs/AlgoliaCleanupIndexJob.php
+++ b/src/jobs/AlgoliaCleanupIndexJob.php
@@ -102,7 +102,7 @@ class AlgoliaCleanupIndexJob extends BaseJob
      */
     protected function queueBatchJob(array $objectIDs): void
     {
-        Craft::$app->getQueue()->push(new AlgoliaCleanupBatchJob([
+        AlgoliaSync::$plugin->pushToQueue(new AlgoliaCleanupBatchJob([
             'objectIDs' => $objectIDs,
             'indexName' => $this->indexName,
             'elementType' => $this->elementType,

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -45,6 +45,7 @@ class Settings extends Model
     public string $algoliaSearch = ''; // ALGOLIA_SEARCH
     public array $algoliaElements = []; // sections, categories, usergroups, etc...
     public bool $appendSiteIdToDefaultSite = false; // append site ID to default site objectIDs
+    public int $queuePriority = 50; // Queue job priority (lower = higher priority, default Craft is 1024)
 
     public function getAlgoliaAdmin(): string
     {

--- a/src/services/AlgoliaSyncService.php
+++ b/src/services/AlgoliaSyncService.php
@@ -191,8 +191,7 @@ class AlgoliaSyncService extends Component
                 $algoliaIndexHandle
             );
 
-            $queue = Craft::$app->getQueue();
-            $queue->push(new AlgoliaSyncTask([
+            AlgoliaSync::$plugin->pushToQueue(new AlgoliaSyncTask([
                 'algoliaIndex' => $algoliaIndex,
                 'algoliaFunction' => 'delete',
                 'algoliaObjectID' => $objectID,
@@ -264,8 +263,7 @@ class AlgoliaSyncService extends Component
             $message .= print_r($recordUpdate['index'], true);
             $message .= print_r($recordUpdate, true);
 
-            $queue = Craft::$app->getQueue();
-            $queue->push(new AlgoliaSyncTask([
+            AlgoliaSync::$plugin->pushToQueue(new AlgoliaSyncTask([
                 'algoliaIndex' => $recordUpdate['index'],
                 'algoliaFunction' => $action,
                 'algoliaObjectID' => $recordUpdate['attributes']['objectID'],
@@ -1531,7 +1529,7 @@ class AlgoliaSyncService extends Component
         }
 
         // Queue the coordinator job
-        Craft::$app->getQueue()->push(new \brilliance\algoliasync\jobs\AlgoliaCleanupCoordinatorJob([
+        AlgoliaSync::$plugin->pushToQueue(new \brilliance\algoliasync\jobs\AlgoliaCleanupCoordinatorJob([
             'batchSize' => 100, // Process 100 records per batch job
         ]));
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -86,6 +86,21 @@
 <a href="{{ cpUrl('utilities/algolia-sync-utility') }}" class="go">Visit the Utilities Page to Cleanup Stale Records</a>
 
 <hr>
+<h1>Queue Settings</h1>
+
+{{ forms.textField({
+    label: 'Queue Job Priority',
+    instructions: 'Priority for Algolia sync queue jobs. Lower numbers = higher priority. Default Craft priority is 1024. Set this lower than other plugins (like Blitz at 100) to process Algolia syncs first.',
+    id: 'queuePriority',
+    name: 'queuePriority',
+    value: settings.queuePriority ?? 50,
+    type: 'number',
+    min: 1,
+    max: 9999,
+    size: 5,
+}) }}
+
+<hr>
 <h1>Algolia API Keys</h1>
 {{ forms.autosuggestField({
     label: 'Algolia Application ID',


### PR DESCRIPTION
- Add queuePriority setting (default 50) to run Algolia jobs before other plugins like Blitz (100)
- Add pushToQueue() helper method using Craft's fluent priority API
- Update all queue push locations to use the new helper
- Add Queue Settings section to plugin settings page