### PR TITLE
5.3.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.2.4-beta - 2026-04-30
+### Fixed
+- Fixed "Undefined array key 0" error when saving elements not configured for Algolia sync (e.g., nested entries in matrix fields)
+- Added empty array check before accessing index in `algoliaElementSynced()` and `prepareAlgoliaSyncElement()`
+
 ## 1.0.0 - 2018-11-23
 ### Added
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 5.2.4-beta - 2026-04-30
+## 5.3.0 - 2026-06-02
+
+First stable release for Craft CMS 5, consolidating the 5.x beta line.
+
+> {warning} Upgrading from 4.x: This release requires Craft CMS 5.0+ and PHP 8.2+, and upgrades the underlying Algolia PHP API client to v4. Multi-site installs now index each element once per site using a per-site `objectID` (for example `123-2`, `123-3`), and the default site keeps the legacy `123` format unless **Append Site ID to Default Site Object IDs** is enabled. After upgrading, re-index your content and run the Cleanup Stale Records utility to remove any records left behind by the previous object ID format.
+
+### Added
+- **Multi-site support**: Each element is indexed separately per site with a unique `objectID`, plus `siteId`, `siteHandle`, and `siteLanguage` attributes for filtering. Elements can be enabled on one site and disabled on another.
+- **Append Site ID to Default Site Object IDs** setting to opt the default site into the `123-1` object ID format for consistency across sites.
+- **Stale record cleanup**: A queue-based cleanup system that removes records for elements that have been deleted, disabled, or expired in Craft. Available as the `algolia-sync/default/cleanup-stale-records` console command and as a control panel utility.
+- **Expiry date handling**: Elements are automatically removed from Algolia when their expiry date passes.
+- **Configurable queue priority**: Control where Algolia Sync jobs sit in Craft's queue (Settings > Plugins > Algolia Sync). Default is 50; lower values run sooner. Valid range is 1-9999.
+- **Universal indexing**: Multiple element types can be configured to use a single shared index, with an `elementType` attribute for filtered searches.
+- Support for Craft Commerce 5 products and variants, including variant attributes.
+- Support for the CKEditor field type.
+- Environment variable support for custom index name overrides (for example `$ORGANIZATIONS_INDEX_NAME`).
+
+### Changed
+- Updated for Craft CMS 5 (API method calls now use property accessors and the `entries` service).
+- Upgraded to the Algolia PHP API client v4.
+- Drafts and revisions are no longer synced; only canonical elements are sent to Algolia, on both save and delete.
+- Custom index overrides that reference an undefined environment variable are now skipped with a log message instead of being sent to Algolia as an empty index. This prevents queue jobs from failing with a `indexName is required` error and avoids misrouting data to a default index.
+
 ### Fixed
-- Fixed "Undefined array key 0" error when saving elements not configured for Algolia sync (e.g., nested entries in matrix fields)
-- Added empty array check before accessing index in `algoliaElementSynced()` and `prepareAlgoliaSyncElement()`
+- Fixed multi-site sync issues including duplicate record syncing, missing content for some enabled sites, and incorrect handling of bulk enable/disable operations.
+- Fixed the cleanup process when multiple element types share a single universal index.
+- Fixed "Undefined array key 0" error when saving elements not configured for Algolia sync (for example, nested entries in Matrix fields).
 
 ## 1.0.0 - 2018-11-23
 ### Added

--- a/src/AlgoliaSync.php
+++ b/src/AlgoliaSync.php
@@ -249,26 +249,8 @@ class AlgoliaSync extends Plugin
                     return $event;
                 }
 
-                // Diagnostic logging to understand draft/revision behavior
-                $isDraft = ElementHelper::isDraft($event->element);
-                $isRevision = ElementHelper::isRevision($event->element);
-                $canonicalId = $event->element->getCanonicalId();
-                $elementId = $event->element->id;
-                $isCanonical = ($canonicalId === $elementId || $canonicalId === null);
-
-                AlgoliaSync::$plugin->algoliaSyncService->logger(
-                    "EVENT_AFTER_SAVE_ELEMENT - ID: {$elementId}, Canonical: {$canonicalId}, isDraft: " . ($isDraft ? 'true' : 'false') . ", isRevision: " . ($isRevision ? 'true' : 'false') . ", isCanonical: " . ($isCanonical ? 'true' : 'false'),
-                    basename(__FILE__),
-                    __LINE__
-                );
-
                 // Skip drafts and revisions - only sync canonical elements
                 if (ElementHelper::isDraftOrRevision($event->element)) {
-                    AlgoliaSync::$plugin->algoliaSyncService->logger(
-                        "Skipping draft/revision sync for element ID {$elementId} (canonical ID: {$canonicalId})",
-                        basename(__FILE__),
-                        __LINE__
-                    );
                     return $event;
                 }
 

--- a/src/services/AlgoliaSyncService.php
+++ b/src/services/AlgoliaSyncService.php
@@ -550,321 +550,6 @@ class AlgoliaSyncService extends Component
         return null;
     }
 
-//    public function prepareAlgoliaSyncElement($element, $action = 'save', $algoliaMessage = '') {
-//
-//        $elementInfo = AlgoliaSync::$plugin->algoliaSyncService->getEventElementInfo($element);
-//        $elementTypeSlug = $elementInfo['type'];
-//
-//        AlgoliaSync::$plugin->algoliaSyncService->logger("This type of item has been saved:: ".$elementTypeSlug, basename(__FILE__) , __LINE__);
-//        // do we update this type of element?
-//        $recordUpdate = array();
-//
-//        $okayToSync = AlgoliaSync::$plugin->algoliaSyncService->algoliaElementSynced($element);
-//
-//        if ($okayToSync) {
-//            AlgoliaSync::$plugin->algoliaSyncService->logger("We are going to sync", basename(__FILE__) , __LINE__);
-//
-//            // what type of element
-//            // user, entry, category
-//            $recordUpdate['attributes'] = array();
-//
-//            if ($action == 'delete') {
-//                $algoliaAction = 'delete';
-//            } else {
-//                if ($element->enabled) {
-//                    $algoliaAction = 'insert';
-//                } else {
-//                    $algoliaAction = 'delete';
-//                }
-//            }
-//            // get the attributes of the entity
-//            $recordUpdate['attributes']['objectID'] = $element->id.'-'.$element->siteId;
-//            $recordUpdate['attributes']['message'] = (int)$element->id;
-//
-//            // Get the list of enabled sites
-//            $enabledSitesIds = [];
-//            $enabledSiteHandles = [];
-//
-//            $allSites = Craft::$app->getSites()->getAllSites();
-//
-//            foreach ($allSites as $site) {
-//                // Query the database directly for the element's enabled status in this site
-//                $isEnabled = (new Query())
-//                    ->select(['enabled'])
-//                    ->from(['{{%elements_sites}}'])
-//                    ->where(['elementId' => $element->id, 'siteId' => $site->id])
-//                    ->scalar();
-//
-//                if ($isEnabled == 1) {
-//                    $enabledSitesIds[] = $site->id;
-//                    $enabledSiteHandles[] = $site->handle;
-//                }
-//            }
-//
-//            $recordUpdate['attributes']['siteIds'] = $enabledSitesIds;
-//            $recordUpdate['attributes']['siteHandles'] = $enabledSiteHandles;
-//
-//            if (isset($element->slug)) {
-//                $recordUpdate['attributes']['slug'] = $element->slug;
-//            }
-//            if (isset($element->authorId)) {
-//                $recordUpdate['attributes']['authorId'] = (int)$element->authorId;
-//            }
-//            if (isset($element->postDate)) {
-//                $recordUpdate['attributes']['postDate'] = (int)$element->postDate->getTimestamp();
-//            }
-//
-//            if (!empty($element->product)) {
-//                $fields = $element->product->getFieldLayout()->getCustomFields();
-//            } else {
-//                $fields = $element->getFieldLayout()->getCustomFields();
-//            }
-//
-//            $arrayFieldTypes = array('entries','tags','users');
-//
-//            foreach ($fields AS $field) {
-//                $fieldHandle = $field->handle;
-//
-//                // send this off to a function to extract the specific information
-//                // based on what type of field it is (asset, text, varchar, etc...)
-//                $fieldName = AlgoliaSync::$plugin->algoliaSyncService->sanitizeFieldName($field->name);
-//
-//                $rawData = AlgoliaSync::$plugin->algoliaSyncService->getFieldData($element, $field, $fieldHandle);
-//
-//                if ($rawData instanceof \craft\ckeditor\data\FieldData) {
-//                    $recordUpdate['attributes'][$fieldName] = $rawData->getRawContent();;
-//                    }
-//                elseif (isset($rawData['type']) && in_array($rawData['type'], $arrayFieldTypes)) {
-//                    $recordUpdate['attributes'][$fieldName] = $rawData['titles'];
-//                    $idsFieldName = $fieldName.'Ids';
-//                    $recordUpdate['attributes'][$idsFieldName] = $rawData['ids'];
-//                }
-//                elseif (isset($rawData['type']) && $rawData['type'] == 'mapfield') {
-//                    $recordUpdate['attributes'][$fieldName] = $rawData;
-//                    $recordUpdate['attributes'][$fieldName.'_address'] = $rawData['address'];
-//                    $recordUpdate['attributes'][$fieldName.'_lat'] = $rawData['lat'];
-//                    $recordUpdate['attributes'][$fieldName.'_lng'] = $rawData['lng'];
-//                    $recordUpdate['attributes'][$fieldName.'_zoom']['zoom'] = $rawData['zoom'];
-//                    if (!empty($rawData['lat']) && !empty($rawData['lng'])) {
-//                        // https://www.algolia.com/doc/guides/managing-results/refine-results/geolocation/#enabling-geo-search-by-adding-geolocation-data-to-records
-//                        // inject a _geoloc into Algolia
-//                        // this doesn't take into account if there are multiple _geoloc...
-//                        // that will be more complex to resolve
-//                        $recordUpdate['attributes']['_geoloc'] = [];
-//                        $recordUpdate['attributes']['_geoloc']['lat'] = $rawData['lat'];
-//                        $recordUpdate['attributes']['_geoloc']['lng'] = $rawData['lng'];
-//                    }
-//                }
-//                elseif (isset($rawData['type']) && $rawData['type'] == 'categories') {
-//
-//                    $recordUpdate['attributes'][$fieldName] = $rawData['flat'];
-//                    $nestedName = $fieldName."_hx";
-//                    $recordUpdate['attributes'][$nestedName] = $rawData['nested'];
-//
-//                }
-//                else {
-//                    $recordUpdate['attributes'][$fieldName] = $rawData;
-//                }
-//
-//                $fieldTypeLong = get_class($field);
-//                $fieldTypeArray = explode('\\', $fieldTypeLong);
-//                $fieldType = strtolower(array_pop($fieldTypeArray));
-//
-//                // for the date field, create a few versions of the date
-//                // todo : add in a config for custom date format to be added
-//                if ($fieldType == 'date') {
-//                    // get the friendly date
-//                    $friendlyName = $fieldName . "_friendly";
-//                    $friendlyDate = date('n/j/Y', $rawData);
-//                    $recordUpdate['attributes'][$friendlyName] = $friendlyDate;
-//
-//                    // get the previous midnight of the current date (unix timestamp)
-//                    $midnightName = $fieldName . "_midnight";
-//                    $midnightTimestamp = mktime(0, 0, 0, date('n', $rawData), date('j', $rawData), date('Y', $rawData));
-//                    $recordUpdate['attributes'][$midnightName] = $midnightTimestamp;
-//                }
-//            }
-//
-//            $recordUpdate['index'] = AlgoliaSync::$plugin->algoliaSyncService->getAlgoliaIndex($element);
-//
-//            switch ($elementTypeSlug) {
-//                case 'category':
-//                case 'entry':
-//                case 'asset':
-//                case 'tag':
-//
-//                    $recordUpdate['elementType'] = ucwords($elementTypeSlug);
-//                    $recordUpdate['handle'] = $elementInfo['sectionHandle'];
-//                    $recordUpdate['attributes']['title'] = $element->title;
-//                    break;
-//
-//                case 'user':
-//                    $recordUpdate['elementType'] = 'User';
-//                    $recordUpdate['handle'] = $elementInfo['sectionHandle'];
-//                    $recordUpdate['attributes']['title'] = $element->username;
-//                    $recordUpdate['attributes']['firstname'] = $element->firstName;
-//                    $recordUpdate['attributes']['lastname'] = $element->lastName;
-//                    $recordUpdate['attributes']['email'] = $element->email;
-//                    $userGroups = $element->getGroups();
-//                    $groupList = [];
-//                    foreach ($userGroups AS $group) {
-//                        $groupList[] = $group->handle;
-//                    }
-//                    $recordUpdate['attributes']['userGroups'] = $groupList;
-//                    break;
-//
-//                case 'product':
-//
-//                    $defaultVariant = $element->defaultVariant;
-//
-//                    if (isset($defaultVariant) &&  isset($defaultVariant->onSale)) {
-//                        $salePrice = (float)$defaultVariant->salePrice;
-//                        $onSale = true;
-//                    }
-//                    else {
-//                        $salePrice = null;
-//                        $onSale = false;
-//                    }
-//
-//                    AlgoliaSync::$plugin->algoliaSyncService->logger("Product is being loaded", basename(__FILE__) , __LINE__);
-//
-//                    // get the basic product info
-//                    $recordUpdate['elementType'] = ucwords($elementTypeSlug);
-//                    $recordUpdate['handle'] = $elementInfo['sectionHandle'][0] ?? null;
-//                    $recordUpdate['attributes']['title'] = $element->title ?? null;
-//
-//                    if (isset($element->id)) {
-//                        $recordUpdate['attributes']['productId'] = $element->id;
-//                    }
-//                    if (isset($element->typeId)) {
-//                        $recordUpdate['attributes']['typeId'] = $element->typeId;
-//                    }
-//                    if (isset($element->taxCategoryId)) {
-//                        $recordUpdate['attributes']['taxCategoryId'] = $element->taxCategoryId;
-//                    }
-//                    if (isset($element->shippingCategoryId)) {
-//                        $recordUpdate['attributes']['shippingCategoryId'] = $element->shippingCategoryId;
-//                    }
-//                    if (isset($element->defaultSku)) {
-//                        $recordUpdate['attributes']['defaultSku'] = $element->defaultSku;
-//                    }
-//                    if (isset($element->availableForPurchase)) {
-//                        $recordUpdate['attributes']['availableForPurchase'] = (bool)$element->availableForPurchase;
-//                    }
-//                    if (isset($element->defaultVariantId)) {
-//                        $recordUpdate['attributes']['defaultVariantId'] = (int)$element->defaultVariantId;
-//                    }
-//                    if (isset($element->defaultPrice)) {
-//                        $recordUpdate['attributes']['defaultPrice'] = (float)$element->defaultPrice;
-//                    }
-//                    if (isset($element->defaultWidth)) {
-//                        $recordUpdate['attributes']['defaultWidth'] = $element->defaultWidth;
-//                    }
-//                    if (isset($element->defaultHeight)) {
-//                        $recordUpdate['attributes']['defaultHeight'] = $element->defaultHeight;
-//                    }
-//                    if (isset($element->defaultLength)) {
-//                        $recordUpdate['attributes']['defaultLength'] = $element->defaultLength;
-//                    }
-//                    if (isset($element->defaultWeight)) {
-//                        $recordUpdate['attributes']['defaultWeight'] = $element->defaultWeight;
-//                    }
-//                    if (isset($element->taxCategory)) {
-//                        $recordUpdate['attributes']['taxCategory'] = $element->taxCategory;
-//                    }
-//
-//
-//                    if (isset($elementInfo['productTypeName'])) {
-//                        $recordUpdate['attributes']['ProductType'] = $elementInfo['productTypeName'];
-//                    }
-//
-//                    if (isset($onSale)) {
-//                        $recordUpdate['attributes']['onSale'] = $onSale; // Assuming $onSale is already a boolean or correct type
-//                    }
-//                    if (isset($salePrice)) {
-//                        $recordUpdate['attributes']['salePrice'] = $salePrice; // Assuming $salePrice is already a number/string or correct type
-//                    }
-//
-//                    // now load all variants
-//                    $getAllVariants = \craft\commerce\elements\Variant::find()->productId($element->id);
-//
-//                    $recordUpdate['attributes']['variants'] = [];
-//
-//                    foreach ($getAllVariants AS $variantDetails) {
-//
-//                        $variantInfo = [];
-//
-//                        $variantInfo['title'] = $variantDetails->title ?? null;
-//
-//                        $variantInfo['variantId'] = $variantDetails->id ?? null;
-//
-//                        if (isset($variantDetails->productId)) {
-//                            $variantInfo['productId'] = (int)$variantDetails->productId;
-//                        }
-//                        if (isset($variantDetails->isDefault)) {
-//                            $variantInfo['isDefault'] = (bool)$variantDetails->isDefault;
-//                        }
-//                        if (isset($variantDetails->price)) {
-//                            $variantInfo['price'] = (float)$variantDetails->price;
-//                        }
-//                        if (isset($variantDetails->sortOrder)) {
-//                            $variantInfo['sortOrder'] = (int)$variantDetails->sortOrder;
-//                        }
-//                        if (isset($variantDetails->width)) {
-//                            $variantInfo['width'] = (float)$variantDetails->width;
-//                        }
-//                        if (isset($variantDetails->height)) {
-//                            $variantInfo['height'] = (float)$variantDetails->height;
-//                        }
-//                        if (isset($variantDetails->length)) {
-//                            $variantInfo['length'] = (float)$variantDetails->length;
-//                        }
-//                        if (isset($variantDetails->stock)) {
-//                            $variantInfo['stock'] = (int)$variantDetails->stock;
-//                        }
-//                        if (isset($variantDetails->weight)) {
-//                            $variantInfo['weight'] = (float)$variantDetails->weight;
-//                        }
-//                        if (isset($variantDetails->hasUnlimitedStock)) {
-//                            $variantInfo['hasUnlimitedStock'] = (bool)$variantDetails->hasUnlimitedStock;
-//                        }
-//                        if (isset($variantDetails->minQty)) {
-//                            $variantInfo['minQty'] = (int)$variantDetails->minQty;
-//                        }
-//                        if (isset($variantDetails->maxQty)) {
-//                            // Note: maxQty might be 0 or null when there's no maximum.
-//                            // isset() handles the null case. If 0 is a meaningful value you want,
-//                            // this check is still correct as 0 is considered "set".
-//                            $variantInfo['maxQty'] = (int)$variantDetails->maxQty;
-//                        }
-//
-//                        // nest each variant under the product info
-//                        $recordUpdate['attributes']['variants'][] = $variantInfo;
-//
-//                    }
-//
-//                    break;
-//
-//            }
-//
-//            // Fire event for tracking before the sync event.
-//            $event = new beforeAlgoliaSyncEvent([
-//                'recordElement' => $element,
-//                'recordUpdate' => $recordUpdate
-//            ]);
-//
-//            $this->trigger(self::EVENT_BEFORE_ALGOLIA_SYNC, $event);
-//            $recordUpdate = $event->recordUpdate;
-//
-//            // $recordUpdate['elementType']
-//            AlgoliaSync::$plugin->algoliaSyncService->algoliaSyncRecord($algoliaAction, $recordUpdate, $algoliaMessage);
-//        }
-//        else {
-//            AlgoliaSync::$plugin->algoliaSyncService->logger("Not okay to sync...", basename(__FILE__) , __LINE__);
-//        }
-//    }
-
-
     public function prepareAlgoliaSyncElement($element, $action = 'save', $algoliaMessage = '')
     {
         // Gather element info and short-circuit if not synced
@@ -1264,11 +949,24 @@ class AlgoliaSyncService extends Component
                 foreach ($syncedGroupsArray AS $groupId => $groupData) {
                     if (!empty($groupData['sync'])) {
                         // does this have a custom index name?
-                        $potentialIndexOverride = $groupData['customIndex'];
+                        $potentialIndexOverride = $groupData['customIndex'] ?? null;
 
                         if (!empty($potentialIndexOverride)) {
                             // is that name an env variable?
-                            $syncedGroups[] = App::parseEnv($potentialIndexOverride);
+                            $resolvedIndex = App::parseEnv($potentialIndexOverride);
+
+                            // Skip (and log) an override that resolves to an empty value
+                            // rather than adding a null index that would fail in the queue.
+                            if (empty($resolvedIndex)) {
+                                $this->logger(
+                                    "Custom index override '{$potentialIndexOverride}' for user group {$groupId} resolved to an empty value - is the environment variable defined in this environment?",
+                                    basename(__FILE__),
+                                    __LINE__
+                                );
+                            }
+                            else {
+                                $syncedGroups[] = $resolvedIndex;
+                            }
                         }
                         else {
                             // otherwise, use the default convention
@@ -1375,13 +1073,39 @@ class AlgoliaSyncService extends Component
         $allSettings = AlgoliaSync::$plugin->getSettings();
         $eventInfo = AlgoliaSync::$plugin->algoliaSyncService->getEventElementInfo($element, false);
 
+        $overrideConfigured = false;
+
         foreach ($eventInfo['sectionId'] as $sectionId) {
-            $potentialIndexOverride = $allSettings['algoliaElements'][$eventInfo['type']][$sectionId]['customIndex'];
+            $potentialIndexOverride = $allSettings['algoliaElements'][$eventInfo['type']][$sectionId]['customIndex'] ?? null;
 
             if (!empty($potentialIndexOverride)) {
-                $returnIndex[] = App::parseEnv($potentialIndexOverride);
+                $overrideConfigured = true;
+                $resolvedIndex = App::parseEnv($potentialIndexOverride);
+
+                // A custom index override that references an environment variable
+                // (e.g. "$ORGANIZATIONS_INDEX_NAME") resolves to null when that variable
+                // is not defined in the current environment. Skip it with a clear log
+                // rather than queueing a sync job with a null index, which would otherwise
+                // fail later in the queue with a cryptic "indexName is required" error.
+                if (empty($resolvedIndex)) {
+                    $this->logger(
+                        "Custom index override '{$potentialIndexOverride}' for {$eventInfo['type']}/{$sectionId} resolved to an empty value - is the environment variable defined in this environment?",
+                        basename(__FILE__),
+                        __LINE__
+                    );
+                    continue;
+                }
+
+                $returnIndex[] = $resolvedIndex;
                 return $returnIndex;
             }
+        }
+
+        // If a custom index override was configured but could not be resolved, do not
+        // fall back to the default index name - that would route data to an unexpected
+        // index. Return an empty array so the element is skipped (and logged) instead.
+        if ($overrideConfigured && empty($returnIndex)) {
+            return $returnIndex;
         }
 
         $env = $this->getEnvironment();

--- a/src/services/AlgoliaSyncService.php
+++ b/src/services/AlgoliaSyncService.php
@@ -169,6 +169,13 @@ class AlgoliaSyncService extends Component
 
             // at this point, we should remove the product from the index - we don't know if it was already there...
             $algoliaIndex = AlgoliaSync::$plugin->algoliaSyncService->getAlgoliaIndex($element);
+
+            // Skip if no index is configured for this element (e.g., nested entries in matrix fields)
+            if (empty($algoliaIndex)) {
+                AlgoliaSync::$plugin->algoliaSyncService->logger("No Algolia index configured for this element, skipping", basename(__FILE__) , __LINE__);
+                return false;
+            }
+
             $objectID = $this->generateObjectID($element);
 
             // Generate meaningful queue message matching the format used elsewhere
@@ -179,7 +186,7 @@ class AlgoliaSyncService extends Component
             $site = Craft::$app->getSites()->getSiteById($element->siteId);
             $siteHandle = $site ? $site->handle : 'unknown';
             $siteId = $element->siteId;
-            $algoliaIndexHandle = is_array($algoliaIndex) ? $algoliaIndex[0] : $algoliaIndex;
+            $algoliaIndexHandle = is_array($algoliaIndex) && !empty($algoliaIndex) ? $algoliaIndex[0] : $algoliaIndex;
 
             $queueMessage = sprintf(
                 'Algolia Sync: Deleting %s "%s (id: %s)", Site: "%s (id: %d)", Index "%s"',
@@ -886,12 +893,19 @@ class AlgoliaSyncService extends Component
         $isDelete = ($action === 'delete' || !$isEnabled || $isExpired);
         $algoliaAction = $isDelete ? 'delete' : 'insert';
         $algoliaActionTitle = $isDelete ? 'Deleting' : 'Inserting';
-        $algoliaIndexHandle = $this->getAlgoliaIndex($element)[0];
+
+        // Get the Algolia index - skip if none configured (e.g., nested entries in matrix fields)
+        $algoliaIndexes = $this->getAlgoliaIndex($element);
+        if (empty($algoliaIndexes)) {
+            $this->logger("No Algolia index configured for element {$element->id}, skipping", __FILE__, __LINE__);
+            return;
+        }
+        $algoliaIndexHandle = $algoliaIndexes[0];
 
         // Build base payload
         $recordTemplate = [
             'attributes' => [],
-            'index' => $this->getAlgoliaIndex($element),
+            'index' => $algoliaIndexes,
             'elementType' => ucwords($type),
             'handle' => $elementInfo['sectionHandle'],
         ];


### PR DESCRIPTION
First stable release for Craft CMS 5, consolidating the 5.x beta line.

## Summary
- Comprehensive 5.3.0 CHANGELOG entry with a 4.x to 5.x upgrade note (Craft 5.0+, PHP 8.2+, Algolia client v4, per-site object ID format, re-index and cleanup guidance).
- Custom index overrides that reference an undefined environment variable are now skipped with a clear log message instead of queueing a sync job with a null index name (which previously failed with "indexName is required"). Healthy syncs are unchanged; unresolved overrides no longer fall back to a default index.
- Removed ~313 lines of dead commented-out prepareAlgoliaSyncElement code.
- Removed temporary draft/revision diagnostic logging from the save-element handler.

## Notes
- Brings v5 from 5.2.3-beta up to 5.3.0, including the previously-unmerged 5.2.4 empty-array fix.
- schemaVersion intentionally unchanged (no new migrations).

## Follow-up (not in this PR)
- The stale-record cleanup path resolves custom index env vars separately and could benefit from the same empty-index guard.