### PR TITLE
Matrix field support (5.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.4.0 - 2026-06-02
+
+### Added
+- **Matrix field support**: Matrix field content is now indexed automatically, with no per-field configuration, including nested Matrix fields at unlimited depth. Each Matrix field produces a flattened searchable text attribute (`<handle>_text`) and a de-duplicated list of block types (`<handle>_blockTypes`) for faceting.
+- **Include Structured Matrix Payload** setting (off by default) to also store the full nested block structure on the record for front-ends that render results directly from Algolia.
+- **Sync Matrix Fields**, **Matrix Maximum Depth**, and **Record Size Budget** settings to control Matrix indexing behavior.
+
+### Changed
+- Records that exceed the configured size budget are now gracefully degraded (structured payloads dropped, then long text trimmed) instead of failing, keeping records under Algolia's size limit.
+
+### Fixed
+- Date fields that are empty no longer generate derived date attributes from a null value.
+
 ## 5.3.0 - 2026-06-02
 
 First stable release for Craft CMS 5, consolidating the 5.x beta line.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,40 @@ Product records include:
 - Sale pricing and on-sale flags
 - Stock information
 
+### Matrix Fields
+
+Matrix field content is indexed automatically, with no per-field configuration. Because Craft 5 Matrix blocks are nested entries that can themselves contain Matrix fields, content of virtually unlimited depth is supported. The content is flattened into a search-friendly shape rather than mirrored as a deep object tree, which keeps records well within Algolia's size limit and gives reliable relevance and faceting.
+
+For a Matrix field with the handle `documentation`, each record gets:
+
+- `documentation_text` (string) - a flattened, searchable aggregate of the text from every block at every depth. Point your index's searchable attributes here.
+- `documentation_blockTypes` (array of strings) - a de-duplicated list of every block (entry type) handle found at any depth, ideal for faceting (for example, "show entries that contain a `callToAction` block").
+- `documentation` (object) - the full nested block structure. This is **optional and off by default**; enable **Include Structured Matrix Payload** in the settings only if your front-end renders results directly from the Algolia record.
+
+Example: a product with a `documentation` Matrix field containing three `document` blocks, where each document has its own `relatedDocuments` Matrix field, produces:
+
+```json
+{
+  "documentation_text": "Installation Guide. How to install the Widget Pro. Quick Start. 5 minute setup. Safety Sheet. User Manual. Complete reference. Warranty. 2 year warranty terms. Claim Form.",
+  "documentation_blockTypes": ["document", "relatedDoc"]
+}
+```
+
+The flattened text answers "does this entry mention X?" perfectly at any depth. The optional structured payload is what preserves which related document belongs to which parent document, when you need that association for display.
+
+Settings (under **Settings → Algolia Sync → Matrix Fields**):
+
+- **Sync Matrix Fields** - master toggle (on by default).
+- **Matrix Maximum Depth** - how many nested levels to traverse (default 10).
+- **Record Size Budget (bytes)** - records over this size are gracefully degraded (structured payload dropped, then long text trimmed) rather than failing. Default 9000, under Algolia's ~10,000-byte limit.
+- **Include Structured Matrix Payload** - emit the full nested object (off by default).
+
+For per-field or per-entry customization, use the `EVENT_BEFORE_ALGOLIA_SYNC` event (see [Event System](#event-system)) to adjust the record before it is sent to Algolia.
+
+> Note: CKEditor fields are indexed as their rendered text. Entries embedded inside a CKEditor field are not yet recursed into; this is planned for a future release.
+
+> After enabling Matrix syncing on existing content, run a bulk load (below) so the new attributes are populated on records that have not been re-saved.
+
 ## Bulk Loading
 
 To initially populate or refresh your Algolia indexes:

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -47,6 +47,12 @@ class Settings extends Model
     public bool $appendSiteIdToDefaultSite = false; // append site ID to default site objectIDs
     public int $queuePriority = 50; // Queue job priority (lower = higher priority, default Craft is 1024)
 
+    // Matrix field syncing
+    public bool $syncMatrixFields = true;              // automatically index Matrix field content
+    public int $matrixMaxDepth = 10;                   // max nesting depth to traverse (size/perf cap)
+    public int $matrixTextByteBudget = 9000;           // max bytes for record attributes before degrading (Algolia limit ~10KB)
+    public bool $includeStructuredMatrixPayload = false; // also emit the full nested block object (off by default)
+
     public function getAlgoliaAdmin(): string
     {
         return App::parseEnv($this->algoliaAdmin);

--- a/src/services/AlgoliaSyncService.php
+++ b/src/services/AlgoliaSyncService.php
@@ -390,7 +390,7 @@ class AlgoliaSyncService extends Component
             }
         }
     }
-    public function getFieldData($element, $field, $fieldHandle): mixed
+    public function getFieldData($element, $field, $fieldHandle, int $depth = 0): mixed
     {
         if (get_class($field) === 'craft\ckeditor\Field') {
             $fieldType = 'ckeditor';
@@ -454,6 +454,72 @@ class AlgoliaSyncService extends Component
                     'type' => $fieldType,
                     'ids'   => $idsArray,
                     'titles'    => $titlesArray
+                );
+
+            case 'matrix':
+                $settings = AlgoliaSync::$plugin->getSettings();
+
+                if (!$settings->syncMatrixFields) {
+                    return null;
+                }
+
+                // maxMatrixDepth is a size/performance control. Saved Matrix content is a
+                // finite tree (a block cannot contain itself), so this is not needed for
+                // correctness - it simply caps how deep we will traverse and index.
+                if ($depth >= $settings->matrixMaxDepth) {
+                    $this->logger(
+                        "Matrix max depth ({$settings->matrixMaxDepth}) reached at field '{$fieldHandle}'; not recursing further",
+                        basename(__FILE__),
+                        __LINE__
+                    );
+                    return null;
+                }
+
+                // In Craft 5 a Matrix field's value is an EntryQuery of nested entries (blocks).
+                // Index enabled blocks only.
+                $blocks = $element->$fieldHandle->status('enabled')->all();
+
+                $structuredBlocks = [];
+                $blockTypes = [];
+                $textParts = [];
+
+                foreach ($blocks as $block) {
+                    if (!($block instanceof \craft\elements\Entry)) {
+                        continue;
+                    }
+
+                    $blockTypeHandle = $block->getType()->handle;
+                    $blockTypes[] = $blockTypeHandle;
+
+                    // A block is an Entry with its own field layout - recurse using the same
+                    // per-field mapping so nested Matrix fields, relations, dates, maps, etc.
+                    // are all handled identically at any depth.
+                    $blockAttributes = $this->buildAttributesForElement($block, $depth + 1, false);
+
+                    // Bubble up block-type handles discovered in nested Matrix fields so the
+                    // top-level _blockTypes facet lists every type at every depth.
+                    foreach ($blockAttributes as $attrKey => $attrVal) {
+                        if (is_array($attrVal) && str_ends_with($attrKey, '_blockTypes')) {
+                            $blockTypes = array_merge($blockTypes, $attrVal);
+                        }
+                    }
+
+                    $blockText = $this->extractSearchableText($blockAttributes);
+                    if ($blockText !== '') {
+                        $textParts[] = $blockText;
+                    }
+
+                    $structuredBlocks[] = array_merge(
+                        ['_blockType' => $blockTypeHandle, '_blockLevel' => $depth],
+                        $blockAttributes
+                    );
+                }
+
+                return array(
+                    'type'       => 'matrix',
+                    'text'       => implode('. ', $textParts),
+                    'blockTypes' => array_values(array_unique($blockTypes)),
+                    'blocks'     => $structuredBlocks,
                 );
 
             case 'number':
@@ -548,6 +614,191 @@ class AlgoliaSyncService extends Component
                 return $mapInfo;
         }
         return null;
+    }
+
+    /**
+     * Build the Algolia attribute array for a single element by iterating its custom fields
+     * and mapping each field's getFieldData() result into attributes.
+     *
+     * This is shared by the top-level element and by every nested Matrix block (which are
+     * themselves entries), so a block's fields get the exact same treatment at any depth.
+     *
+     * @param mixed $element The element (entry, user, product, or nested Matrix block)
+     * @param int $depth Current nesting depth (0 = top-level element)
+     * @param bool $isRoot True for the top-level element; controls root-only promotions like _geoloc
+     * @return array
+     */
+    public function buildAttributesForElement($element, int $depth = 0, bool $isRoot = true): array
+    {
+        $settings = AlgoliaSync::$plugin->getSettings();
+        $attributes = [];
+        $arrayFieldTypes = ['entries', 'tags', 'users'];
+
+        $fieldLayout = $element->getFieldLayout();
+        $fields = $fieldLayout ? $fieldLayout->getCustomFields() : [];
+
+        foreach ($fields as $field) {
+            $handle = $field->handle;
+            $name = $this->sanitizeFieldName($field->name);
+            $raw = $this->getFieldData($element, $field, $handle, $depth);
+
+            if ($raw instanceof \craft\ckeditor\data\FieldData) {
+                $attributes[$name] = $raw->getRawContent();
+            } elseif (isset($raw['type']) && in_array($raw['type'], $arrayFieldTypes)) {
+                $attributes[$name] = $raw['titles'];
+                $attributes[$name . 'Ids'] = $raw['ids'];
+            } elseif (isset($raw['type']) && $raw['type'] === 'mapfield') {
+                $attributes[$name] = $raw;
+                $attributes[$name . '_address'] = $raw['address'];
+                $attributes[$name . '_lat'] = $raw['lat'];
+                $attributes[$name . '_lng'] = $raw['lng'];
+                $attributes[$name . '_zoom'] = $raw['zoom'];
+                // _geoloc is Algolia's reserved geo key and must live at the record root,
+                // so only promote it for the top-level element, never for nested blocks.
+                if ($isRoot && !empty($raw['lat']) && !empty($raw['lng'])) {
+                    $attributes['_geoloc'] = [
+                        'lat' => $raw['lat'],
+                        'lng' => $raw['lng'],
+                    ];
+                }
+            } elseif (isset($raw['type']) && $raw['type'] === 'categories') {
+                $attributes[$name] = $raw['flat'];
+                $attributes[$name . '_hx'] = $raw['nested'];
+            } elseif (isset($raw['type']) && $raw['type'] === 'matrix') {
+                // Flattened searchable text and a flat block-type facet array are always emitted.
+                // The structured nested object is opt-in (off by default) due to record size.
+                $attributes[$name . '_text'] = $raw['text'];
+                $attributes[$name . '_blockTypes'] = $raw['blockTypes'];
+                if ($settings->includeStructuredMatrixPayload) {
+                    $attributes[$name] = [
+                        'type' => 'matrix',
+                        'blocks' => $raw['blocks'],
+                    ];
+                }
+            } else {
+                $attributes[$name] = $raw;
+            }
+
+            // Friendly date formats
+            $classParts = explode('\\', get_class($field));
+            $fieldType = strtolower(end($classParts));
+            if ($fieldType === 'date' && $raw) {
+                $ts = $raw;
+                $attributes[$name . '_friendly'] = date('n/j/Y', $ts);
+                $attributes[$name . '_midnight'] = mktime(
+                    0, 0, 0,
+                    date('n', $ts),
+                    date('j', $ts),
+                    date('Y', $ts)
+                );
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Extract a flat, human-readable searchable string from a built attribute array.
+     * Used to roll Matrix block content (at any depth) into a single text aggregate.
+     *
+     * Skips identifier, facet, and coordinate keys that add noise rather than search value,
+     * and skips associative arrays (structured payloads) - their text is already represented
+     * by sibling *_text strings.
+     *
+     * @param array $attributes
+     * @return string
+     */
+    private function extractSearchableText(array $attributes): string
+    {
+        $skipSuffixes = ['Ids', '_blockTypes', '_midnight', '_lat', '_lng', '_zoom', '_hx'];
+        $parts = [];
+
+        foreach ($attributes as $key => $value) {
+            $skip = false;
+            foreach ($skipSuffixes as $suffix) {
+                if (str_ends_with($key, $suffix)) {
+                    $skip = true;
+                    break;
+                }
+            }
+            if ($skip) {
+                continue;
+            }
+
+            if (is_string($value)) {
+                $clean = trim(strip_tags($value));
+                if ($clean !== '') {
+                    $parts[] = $clean;
+                }
+            } elseif (is_array($value) && array_is_list($value)) {
+                // Flat list of scalar values (e.g. relation titles, multiselect labels)
+                foreach ($value as $item) {
+                    if (is_string($item)) {
+                        $clean = trim($item);
+                        if ($clean !== '') {
+                            $parts[] = $clean;
+                        }
+                    }
+                }
+            }
+            // Numbers, booleans, and associative arrays are intentionally skipped.
+        }
+
+        return implode('. ', $parts);
+    }
+
+    /**
+     * Ensure a record's attribute payload stays under the configured byte budget (Algolia
+     * rejects records over ~10KB). Degrades gracefully rather than letting the queue job throw:
+     * first drops opt-in structured Matrix payloads, then trims the largest string attributes.
+     *
+     * @param array $attributes
+     * @param int $elementId For log context
+     * @return array
+     */
+    private function enforceRecordSizeBudget(array $attributes, int $elementId): array
+    {
+        $budget = AlgoliaSync::$plugin->getSettings()->matrixTextByteBudget;
+        if ($budget <= 0) {
+            return $attributes;
+        }
+
+        $originalSize = strlen(json_encode($attributes));
+        if ($originalSize <= $budget) {
+            return $attributes;
+        }
+
+        // Step 1: drop opt-in structured Matrix payloads (largest, least search value).
+        foreach ($attributes as $key => $value) {
+            if (is_array($value) && ($value['type'] ?? null) === 'matrix') {
+                unset($attributes[$key]);
+            }
+        }
+
+        // Step 2: if still over, iteratively trim the largest string attribute.
+        while (strlen(json_encode($attributes)) > $budget) {
+            $longestKey = null;
+            $longestLen = 0;
+            foreach ($attributes as $key => $value) {
+                if (is_string($value) && strlen($value) > $longestLen) {
+                    $longestKey = $key;
+                    $longestLen = strlen($value);
+                }
+            }
+            if ($longestKey === null || $longestLen <= 50) {
+                break; // nothing meaningful left to trim
+            }
+            $attributes[$longestKey] = mb_substr($attributes[$longestKey], 0, (int)floor($longestLen / 2));
+        }
+
+        $finalSize = strlen(json_encode($attributes));
+        $this->logger(
+            "Record for element {$elementId} exceeded the size budget ({$originalSize} > {$budget} bytes); degraded to {$finalSize} bytes (structured Matrix payloads dropped and/or large text trimmed).",
+            basename(__FILE__),
+            __LINE__
+        );
+
+        return $attributes;
     }
 
     public function prepareAlgoliaSyncElement($element, $action = 'save', $algoliaMessage = '')
@@ -725,56 +976,15 @@ class AlgoliaSyncService extends Component
                 // nest each variant under the product info
                 $recordTemplate['attributes']['variants'][] = $variantInfo;
             }
-            $fields = $element->getFieldLayout()->getCustomFields();
-        } else {
-
-            $fields = $element->getFieldLayout()->getCustomFields();
         }
-        $arrayFieldTypes = ['entries', 'tags', 'users'];
 
-        foreach ($fields as $field) {
-            $handle = $field->handle;
-            $name = $this->sanitizeFieldName($field->name);
-            $raw = $this->getFieldData($element, $field, $handle);
-
-            if ($raw instanceof \craft\ckeditor\data\FieldData) {
-                $recordTemplate['attributes'][$name] = $raw->getRawContent();
-            } elseif (isset($raw['type']) && in_array($raw['type'], $arrayFieldTypes)) {
-                $recordTemplate['attributes'][$name] = $raw['titles'];
-                $recordTemplate['attributes'][$name . 'Ids'] = $raw['ids'];
-            } elseif (isset($raw['type']) && $raw['type'] === 'mapfield') {
-                $recordTemplate['attributes'][$name] = $raw;
-                $recordTemplate['attributes'][$name . '_address'] = $raw['address'];
-                $recordTemplate['attributes'][$name . '_lat'] = $raw['lat'];
-                $recordTemplate['attributes'][$name . '_lng'] = $raw['lng'];
-                $recordTemplate['attributes'][$name . '_zoom'] = $raw['zoom'];
-                if (!empty($raw['lat']) && !empty($raw['lng'])) {
-                    $recordTemplate['attributes']['_geoloc'] = [
-                        'lat' => $raw['lat'],
-                        'lng' => $raw['lng'],
-                    ];
-                }
-            } elseif (isset($raw['type']) && $raw['type'] === 'categories') {
-                $recordTemplate['attributes'][$name] = $raw['flat'];
-                $recordTemplate['attributes'][$name . '_hx'] = $raw['nested'];
-            } else {
-                $recordTemplate['attributes'][$name] = $raw;
-            }
-
-            // Friendly date formats
-            $classParts = explode('\\', get_class($field));
-            $fieldType = strtolower(end($classParts));
-            if ($fieldType === 'date') {
-                $ts = $raw;
-                $recordTemplate['attributes'][$name . '_friendly'] = date('n/j/Y', $ts);
-                $recordTemplate['attributes'][$name . '_midnight'] = mktime(
-                    0, 0, 0,
-                    date('n', $ts),
-                    date('j', $ts),
-                    date('Y', $ts)
-                );
-            }
-        }
+        // Build custom field attributes. This is extracted into a reusable method so that
+        // Matrix blocks (which are nested entries with their own field layouts) receive the
+        // exact same per-field treatment at every depth.
+        $recordTemplate['attributes'] = array_merge(
+            $recordTemplate['attributes'],
+            $this->buildAttributesForElement($element, 0, true)
+        );
 
         // Determine which sites to sync
         // Only sync the current site when bulk‑loading or saving
@@ -808,6 +1018,15 @@ class AlgoliaSyncService extends Component
         ]);
         $this->trigger(self::EVENT_BEFORE_ALGOLIA_SYNC, $event);
         $recordTemplate = $event->recordUpdate;
+
+        // Keep the record under Algolia's size limit. Only relevant for inserts (deletes
+        // carry just an objectID). Degrades gracefully rather than letting the queue job throw.
+        if ($algoliaAction === 'insert' && !empty($recordTemplate['attributes'])) {
+            $recordTemplate['attributes'] = $this->enforceRecordSizeBudget(
+                $recordTemplate['attributes'],
+                (int)$element->id
+            );
+        }
 
         // Queue a record per site
         foreach ($enabledSites as $siteId => $info) {

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -75,6 +75,49 @@
 }) }}
 
 <hr>
+<h1>Matrix Fields</h1>
+
+{{ forms.lightswitchField({
+    label: 'Sync Matrix Fields',
+    instructions: 'Automatically index the content of Matrix fields, including nested Matrix fields at any depth. Each Matrix field produces a searchable text attribute ("<handle>_text") and a list of block types ("<handle>_blockTypes") for faceting.',
+    id: 'syncMatrixFields',
+    name: 'syncMatrixFields',
+    on: settings.syncMatrixFields ?? true,
+}) }}
+
+{{ forms.textField({
+    label: 'Matrix Maximum Depth',
+    instructions: 'How many levels of nested Matrix fields to traverse. Protects record size and indexing performance on deeply nested content.',
+    id: 'matrixMaxDepth',
+    name: 'matrixMaxDepth',
+    value: settings.matrixMaxDepth ?? 10,
+    type: 'number',
+    min: 1,
+    max: 50,
+    size: 5,
+}) }}
+
+{{ forms.textField({
+    label: 'Record Size Budget (bytes)',
+    instructions: 'Maximum size for a record before it is gracefully degraded (structured payloads dropped, long text trimmed). Algolia rejects records larger than ~10,000 bytes on most plans.',
+    id: 'matrixTextByteBudget',
+    name: 'matrixTextByteBudget',
+    value: settings.matrixTextByteBudget ?? 9000,
+    type: 'number',
+    min: 1000,
+    max: 100000,
+    size: 7,
+}) }}
+
+{{ forms.lightswitchField({
+    label: 'Include Structured Matrix Payload',
+    instructions: 'In addition to the searchable text, also store the full nested block structure as an object on the record. Off by default. Enable this only if your front-end renders results directly from the Algolia record, as it significantly increases record size.',
+    id: 'includeStructuredMatrixPayload',
+    name: 'includeStructuredMatrixPayload',
+    on: settings.includeStructuredMatrixPayload ?? false,
+}) }}
+
+<hr>
 <h1>Bulk Load of Records</h1>
 <a href="{{ cpUrl('utilities/algolia-sync-utility') }}" class="go">Visit the Utilities Page to Bulk Load Records</a>
 


### PR DESCRIPTION
Implements automatic Matrix field syncing (issue #26).

## Approach
Matrix blocks in Craft 5 are nested entries that can themselves contain Matrix fields, so depth is effectively unlimited. Rather than mirror that deep tree into the record (which hurts Algolia relevance/faceting and risks the ~10KB record limit), Matrix content is flattened into a search-friendly shape:

- `<handle>_text` - flattened searchable text from every block at every depth (always on)
- `<handle>_blockTypes` - de-duplicated block-type handles at every depth, for faceting (always on)
- `<handle>` - full structured nested object (opt-in, off by default)

## Key changes
- New `getFieldData()` `matrix` case that recurses into nested blocks.
- Per-field mapping extracted into reusable `buildAttributesForElement($element, $depth, $isRoot)` so blocks get identical treatment at any depth (relations, dates, maps, categories, nested matrices).
- New `enforceRecordSizeBudget()` degrades records gracefully (drop structured payload, then trim largest text) instead of failing under Algolia's size limit.
- Recursion is bounded to nested Matrix only (never relation fields), so no association cycles.
- New settings: `syncMatrixFields` (default on), `matrixMaxDepth` (10), `matrixTextByteBudget` (9000), `includeStructuredMatrixPayload` (off).

## Scope notes
- CKEditor-embedded entries are out of scope this release (indexed as rendered text); documented as a future enhancement.
- Per-field customization is via the existing `EVENT_BEFORE_ALGOLIA_SYNC` event; no per-field UI.

## Verification status
- PHP syntax checks pass; Craft bootstraps and loads the plugin without errors.
- End-to-end testing against Algolia (multi-level matrix entry -> queue -> inspect record, size-guard, multi-site) is pending and should be done in the CP before merging to v5. Steps are in the plan file.

## Backwards compatibility
Additive only. A full bulk reindex is required to populate the new attributes on existing records.