### PR TITLE
Fix: Add asset case to bulk load tasks to prevent 'Unknown element ty…

### DIFF
--- a/src/jobs/AlgoliaBulkLoadTask.php
+++ b/src/jobs/AlgoliaBulkLoadTask.php
@@ -16,6 +16,7 @@ use craft\queue\BaseJob;
 use craft\elements\Entry;
 use craft\elements\Category;
 use craft\elements\User;
+use craft\elements\Asset;
 use craft\commerce\elements\Product;
 use yii\queue\RetryableJobInterface;
 
@@ -93,6 +94,9 @@ class AlgoliaBulkLoadTask extends BaseJob implements RetryableJobInterface
                 $query = User::find()->groupId($sectionId)->site('*');
                 break;
 
+            case 'asset':
+                $query = Asset::find()->volumeId($sectionId)->site('*');
+                break;
             default:
                 Craft::error("Unknown element type: {$elementType}", __METHOD__);
                 return;

--- a/src/jobs/AlgoliaChunkLoadTask.php
+++ b/src/jobs/AlgoliaChunkLoadTask.php
@@ -17,6 +17,7 @@ use craft\base\Element;
 use craft\elements\Entry;
 use craft\elements\Category;
 use craft\elements\User;
+use craft\elements\Asset;
 use craft\commerce\elements\Product;
 
 class AlgoliaChunkLoadTask extends BaseJob
@@ -92,6 +93,15 @@ class AlgoliaChunkLoadTask extends BaseJob
                     ->limit($limit);
                 break;
 
+            case 'asset':
+                $query = Asset::find()
+                    ->volumeId($sectionId)
+                    ->site('*')
+                    ->orderBy([])
+                    ->offset($offset)
+                    ->limit($limit);
+                break;
+
             default:
                 Craft::error("Unknown elementType: {$elementType}", __METHOD__);
                 return;
@@ -156,6 +166,9 @@ class AlgoliaChunkLoadTask extends BaseJob
                     break;
                 case 'user':
                     $allSites = User::find()->id($id)->site('*')->all();
+                    break;
+                case 'asset':
+                    $allSites = Asset::find()->id($id)->site('*')->all();
                     break;
             }
 


### PR DESCRIPTION
## Problem

Bulk loading assets via the CP utility (Utilities → Algolia Sync Utility) fails with `Unknown element type: asset`. The `AlgoliaBulkLoadTask` and `AlgoliaChunkLoadTask` switch statements have no case for `asset` elements.

Individual asset re-saves worked. Only the bulk path was missing.

## My Fix

Adds an `asset` case to both job classes, querying by `volumeId`:

- `AlgoliaBulkLoadTask` builds the base asset query by volume ID
- `AlgoliaChunkLoadTask` adds asset cases to both the query-building switch and the per-site loading switch

## Testing

Tested on Craft CMS 5.10.8.1 with an Uploads volume containing 300+ assets. Bulk load via the CP utility succeed after the fix, seen via the queue-manager page.